### PR TITLE
Use official CSS spec from w3c

### DIFF
--- a/src/getAllCSSProperties.ts
+++ b/src/getAllCSSProperties.ts
@@ -1,21 +1,38 @@
 import fetch from "node-fetch";
 
-export const getAllCSSProperties = () => {
-  const searchRegexp = new RegExp('<li><a href="/css/(.*)">(.*)</a></li>', "igm");
-  return fetch("https://cors-anywhere.herokuapp.com/https://www.quackit.com/css/properties/", {
-    headers: {
-      origin: "http://127.0.0.1",
-    },
-  })
-    .then(r => r.text())
-    .then(text => {
-      const accumulator: Set<string> = new Set(); // let's use a Set to avoid duplicates HOMIE
-      let match: RegExpExecArray | null;
-      while ((match = searchRegexp.exec(text))) {
-        accumulator.add(match[2]);
-      }
-      return Array.from(accumulator)
-        .sort()
-        .slice(2);
-    });
+const IGNORED_PROPERTIES = ["--*"];
+
+export const getAllCSSProperties = async () => {
+  // Use Set to ignore repeating properties and sort them alphabetically.
+  const properties = new Set<string>();
+  try {
+    const response = await fetch(
+      "https://www.w3.org/Style/CSS/all-properties.en.json"
+    );
+    const allProperties = await response.json();
+    // Safety check to make sure that parsed data is actually an array.
+    if (Array.isArray(allProperties)) {
+      /**
+       * CSS properties data is an array of object in the following shape:
+       * [
+       *   {
+       *     property: '--*',
+       *     url: 'http://www.w3.org/TR/2015/CR-css-variables-1-20151203/#propdef-',
+       *     status: 'CR',
+       *     title: 'CSS Custom Properties for Cascading Variables Module Level 1'
+       *   },
+       *   ...
+       * ],
+       * We have to omit some properties that are not relevant.
+       */
+      allProperties.forEach(
+        property =>
+          !IGNORED_PROPERTIES.includes(property.property) &&
+          properties.add(property.property)
+      );
+    }
+  } catch (error) {
+    // Handle errors.
+  }
+  return Array.from(properties.values());
 };


### PR DESCRIPTION
After investigating it more, I've noticed that as the DOM version would work in the browser and could theoretically be polyfilled in node, it wouldn't be the best experience. The polyfill would produce different result. I've checked how the `jsdom` code is implemented and it's using the `cssstyle` package which takes list of the css properties from the official w3c spec, which can be found here in the JSON format: https://www.w3.org/Style/CSS/all-properties.en.json

So instead of using DOM version, I've just updated code to make use of the official spec which should always be up to date. The cli tool, could also take an argument that would filter css properties by status (Release Candidate, Working Draft etc.). Right now, this PR returns all the CSS properties experimental and shipped in browsers.